### PR TITLE
secret managerのimport時に起きる問題のワークアラウンド

### DIFF
--- a/core/service/google_secret_manager.py
+++ b/core/service/google_secret_manager.py
@@ -1,4 +1,4 @@
-from google.cloud import secretmanager
+from google import cloud
 from google.api_core.exceptions import NotFound
 import logging
 
@@ -11,7 +11,7 @@ class GoogleSecretManager(BaseService):
         self.project_id = project_id
 
     def build(self):
-        return secretmanager.SecretManagerServiceClient()
+        return cloud.secretmanager.SecretManagerServiceClient()
 
     def get(self, key, version='latest'):
         try:


### PR DESCRIPTION
secretmanagerをインポートすると、以下のようなエラーが発生する。


```
$ python scripts/run.py
[INFO] 2020-06-30 21:58:57,744: Fetch and update report (2020-06-30)
[DEBUG] 2020-06-30 21:58:57,745: Making request: POST https://accounts.google.com/o/oauth2/token
[DEBUG] 2020-06-30 21:58:57,779: Starting new HTTPS connection (1): accounts.google.com:443
[DEBUG] 2020-06-30 21:58:57,944: https://accounts.google.com:443 "POST /o/oauth2/token HTTP/1.1" 200 None
{'_underlay_call': <_SingleThreadedRendezvous object>, '_failure_handler': <bound method ExceptionInterceptor._handle_grpc_failure of <google.ads.google_ads.interceptors.exception_interceptor.ExceptionInterceptor object at 0x104876f10>>, '_exception': None}
Traceback (most recent call last):
  File "scripts/run.py", line 87, in <module>
    fire.Fire(main)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/fire/core.py", line 138, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/fire/core.py", line 468, in _Fire
    target=component.__name__)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/fire/core.py", line 672, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "scripts/run.py", line 38, in main
    fetch_and_update_ad_report(config, start_date)
  File "scripts/run.py", line 53, in fetch_and_update_ad_report
    with provider.fetch(target_date) as response:
  File "/Users/satoshi/git/adreport/provider/google.py", line 39, in fetch
    response = ga_service.search_stream(customer_id, query)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/ads/google_ads/v3/services/google_ads_service_client.py", line 314, in search_stream
    return self._inner_api_calls['search_stream'](request, retry=retry, timeout=timeout, metadata=metadata)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/api_core/gapic_v1/method.py", line 143, in __call__
    return wrapped_func(*args, **kwargs)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/api_core/retry.py", line 286, in retry_wrapped_func
    on_error=on_error,
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/api_core/retry.py", line 184, in retry_target
    return target()
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/api_core/timeout.py", line 214, in func_with_timeout
    return func(*args, **kwargs)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/api_core/grpc_helpers.py", line 150, in error_remapped_callable
    return _StreamingResponseIterator(result, prefetch_first_result=prefetch_first)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/api_core/grpc_helpers.py", line 73, in __init__
    self._stored_first_result = six.next(self._wrapped)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/grpc/_interceptor.py", line 144, in __next__
    raise self._exception
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/grpc/_interceptor.py", line 336, in __call__
    continuation, client_call_details, request)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/ads/google_ads/interceptors/logging_interceptor.py", line 297, in intercept_unary_stream
    response.add_done_callback(on_rpc_complete)
  File "/Users/satoshi/.local/share/virtualenvs/adreport--f2l0IOi/lib/python3.7/site-packages/google/ads/google_ads/interceptors/exception_interceptor.py", line 73, in add_done_callback
    return self._underlay_call.add_done_callback(fn)
AttributeError: '_SingleThreadedRendezvous' object has no attribute 'add_done_callback'
```